### PR TITLE
fixing optionals types at xcode 6.1

### DIFF
--- a/FireChat-Swift/LoginViewController.swift
+++ b/FireChat-Swift/LoginViewController.swift
@@ -65,7 +65,7 @@ class LoginViewController : UIViewController, UIActionSheetDelegate {
     func handleMultipleTwitterAccounts(accounts: [ACAccount]) {
         switch accounts.count {
         case 0:
-            UIApplication.sharedApplication().openURL(NSURL(string: "https://twitter.com/signup"))
+            UIApplication.sharedApplication().openURL(NSURL(string: "https://twitter.com/signup")!)
         case 1:
             self.authAccount(accounts[0])
         default:

--- a/FireChat-Swift/MessagesViewController.swift
+++ b/FireChat-Swift/MessagesViewController.swift
@@ -63,7 +63,7 @@ class MessagesViewController: JSQMessagesViewController {
         let diameter = incoming ? UInt(collectionView.collectionViewLayout.incomingAvatarViewSize.width) : UInt(collectionView.collectionViewLayout.outgoingAvatarViewSize.width)
         
         let url = NSURL(string: imageUrl!)
-        let image = UIImage(data: NSData(contentsOfURL: url))
+        let image = UIImage(data: NSData(contentsOfURL: url!)!)
         let avatarImage = JSQMessagesAvatarFactory.avatarWithImage(image, diameter: diameter)
         
         avatars[name] = avatarImage


### PR DESCRIPTION
Under xcode 6.1, 3 errors appears:
"error: value of optional type 'NSURL?' not unwrapped; did you mean to use '!' or '?'?"

Whit this little fixes, is compiling again.
