### PR TITLE
Use the configured Firebase

### DIFF
--- a/FireChat-Swift/MessagesViewController.swift
+++ b/FireChat-Swift/MessagesViewController.swift
@@ -27,7 +27,7 @@ class MessagesViewController: JSQMessagesViewController {
 
     func setupFirebase() {
         // *** STEP 2: SETUP FIREBASE
-        messagesRef = Firebase(url: "https://swift-chat.firebaseio.com/messages")
+        messagesRef = self.ref.childByAppendingPath("messages")
 
         // *** STEP 4: RECEIVE MESSAGES FROM FIREBASE (limited to latest 25 messages)
         messagesRef.queryLimitedToNumberOfChildren(25).observeEventType(FEventType.ChildAdded, withBlock: { (snapshot) in


### PR DESCRIPTION
The messages controller uses the default Firebase instead of the one configured like said in the README.
